### PR TITLE
Add delete incidence button

### DIFF
--- a/UI/flags.html
+++ b/UI/flags.html
@@ -44,13 +44,13 @@
                     </tfoot>
                     <tbody>
                     <tr>
-                    <td>Traffic corruption</td><td>I saw a Traffic police take bribe from the driver of KBS 455R</td><td>24/03/2018</td><td>pending</td></tr>
+                    <td>Traffic corruption</td><td>I saw a Traffic police take bribe from the driver of KBS 455R</td><td>24/03/2018</td><td>pending</td><td><button>Delete</button></td></tr>
                     <tr>
-                    <td>County officer corrupt</td><td>I saw a county officer take bribe from a tender bidder</td><td>25/03/2018</td><td>under investigation</td></tr>
+                    <td>County officer corrupt</td><td>I saw a county officer take bribe from a tender bidder</td><td>25/03/2018</td><td>under investigation</td><td><button>Delete</button></td></tr>
                         <tr>
-                    <td>Traffic corruption</td><td>I saw a Traffic police take bribe from a boda-boda motorist who lacked helmet</td><td>24/03/2018</td><td>pending</td></tr>
+                    <td>Traffic corruption</td><td>I saw a Traffic police take bribe from a boda-boda motorist who lacked helmet</td><td>24/03/2018</td><td>pending</td><td><button>Delete</button></td></tr>
                     <tr>
-                    <td>Job Oppotunity</td><td>A HR officer wanted me to offer money for a post in Kitui County</td><td>24/03/2018</td><td>pending</td></tr>
+                    <td>Job Oppotunity</td><td>A HR officer wanted me to offer money for a post in Kitui County</td><td>24/03/2018</td><td>pending</td><td><button>Delete</button></td></tr>
                     </tbody>
                     </table>
                      </div>

--- a/UI/interventions.html
+++ b/UI/interventions.html
@@ -44,13 +44,13 @@
                     </tfoot>
                     <tbody>
                     <tr>
-                    <td>Traffic corruption</td><td>I saw a Traffic police take bribe from the driver of KBS 455R</td><td>24/03/2018</td><td>pending</td></tr>
+                    <td>Broken Bridge</td><td>There is a broken bridge at Katangi</td><td>24/05/2018</td><td>Resolved</td> <td><button>Delete</button></td></tr>
                     <tr>
-                    <td>County officer corrupt</td><td>I saw a county officer take bribe from a tender bidder</td><td>25/03/2018</td><td>under investigation</td></tr>
+                    <td>Floods</td><td>Residents at Makadara suffer great loss after floods</td><td>01/1/2018</td><td>under investigation</td><td><button>Delete</button></td></tr>
                         <tr>
-                    <td>Traffic corruption</td><td>I saw a Traffic police take bribe from a boda-boda motorist who lacked helmet</td><td>24/03/2018</td><td>pending</td></tr>
+                    <td>Drug Abuse</td><td>Many boys in Kitui Township ward has turned to drug abuse. </td><td>24/03/2018</td><td>pending</td><td><button>Delete</button></td></tr>
                     <tr>
-                    <td>Job Oppotunity</td><td>A HR officer wanted me to offer money for a post in Kitui County</td><td>24/03/2018</td><td>pending</td></tr>
+                    <td>Road damaged</td><td>Many people experience difficulties transisting along Mbusyani road. it needs repair</td><td>24/03/2018</td><td>pending</td><td><button>Delete</button></td></tr>
                     </tbody>
                     </table>
                      </div>


### PR DESCRIPTION
**What does this PR do?**
Adds delete feature so the user can delete previously recorded incidences
**Description of tasks to be completed.**
Adds delete button after every so that user can delete previously recorded incidences
**How to test manually?** 
Clone the project. Check out the ft-Delete-IIncidence-#162109111 branch. Open the ui folder and run the flags.html file or the  interventions.html  using a browser.
*Relevant pivotal tracker stories.*  
#162109111
![screenshot from 2018-11-24 04-19-10](https://user-images.githubusercontent.com/19523109/48963279-3a7ee280-efa0-11e8-8d62-3b44dc59a30b.png)
![screenshot from 2018-11-24 04-19-43](https://user-images.githubusercontent.com/19523109/48963281-3a7ee280-efa0-11e8-8068-e45cf809d671.png)

